### PR TITLE
Added: README comment that Windows containers not yet supported in vNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ terraform destroy
 
 #### Terraform ACI DevOps Agents - Deploy Linux agents in an existing virtual network
 
-The configuration below can be used to deploy Azure DevOps agents in Linux containers, in an existing virtual network.
+The configuration below can be used to deploy Azure DevOps agents in Linux containers, in an existing virtual network. Windows containers are not yet supported in a container group deployed to a Virtual Network.
 
 ```hcl
 resource "azurerm_resource_group" "vnet-rg" {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terraform destroy
 ```
 
 #### Terraform ACI DevOps Agents - Deploy Linux agents in an existing virtual network
-
+*Note: Virtual Network integration is only supported for Linux Containers in ACI. This part [does not apply to Windows Containers](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-virtual-network-concepts#other-limitations).*
 The configuration below can be used to deploy Azure DevOps agents in Linux containers, in an existing virtual network. Windows containers are not yet supported in a container group deployed to a Virtual Network.
 
 ```hcl

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ terraform destroy
 
 #### Terraform ACI DevOps Agents - Deploy Linux agents in an existing virtual network
 *Note: Virtual Network integration is only supported for Linux Containers in ACI. This part [does not apply to Windows Containers](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-virtual-network-concepts#other-limitations).*
-The configuration below can be used to deploy Azure DevOps agents in Linux containers, in an existing virtual network. Windows containers are not yet supported in a container group deployed to a Virtual Network.
+The configuration below can be used to deploy Azure DevOps agents in Linux containers, in an existing virtual network.
 
 ```hcl
 resource "azurerm_resource_group" "vnet-rg" {


### PR DESCRIPTION
Windows containers are not yet supported in a container group in a Virtual Net (https://docs.microsoft.com/en-us/azure/container-instances/container-instances-virtual-network-concepts#other-limitations)

Adding this note as it cost me some time to implement the module and then receive the message that it isn't supported at present.