### PR TITLE
Update tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Pull the base image with given version.
 ARG BUILD_TERRAFORM_VERSION="0.14.4"
-FROM jcorioland/terraform-test:${BUILD_TERRAFORM_VERSION}
+FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
-ARG MODULE_NAME="terraform-azure-devops-eagent-aci"
+ARG MODULE_NAME="terraform-azure-devops-agent-aci"
 
 # Declare default build configurations for terraform.
 ARG BUILD_ARM_SUBSCRIPTION_ID=""

--- a/test/azure_devops_agent_aci_test.go
+++ b/test/azure_devops_agent_aci_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2020-11-01/containerinstance"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2020-11-01/containerinstance"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
 // This function tests the deployment of Azure DevOps Linux agents
@@ -153,8 +153,8 @@ func TestDeployAzureDevOpsLinuxAgentsWithManagedIdentities(t *testing.T) {
 		}
 
 		if expectedAgentSystemIdentitiesCount != systemIdentitiesCount || expectedAgentUserAssignedIdentitiesCount != userAssignedIdentitiesCount {
-			t.Fatalf("Test failed. System identities: %d (actual) vs %d (expected), user assigned identities %d (actual) vs %d (expected)", 
-			systemIdentitiesCount, expectedAgentSystemIdentitiesCount, userAssignedIdentitiesCount, expectedAgentUserAssignedIdentitiesCount)
+			t.Fatalf("Test failed. System identities: %d (actual) vs %d (expected), user assigned identities %d (actual) vs %d (expected)",
+				systemIdentitiesCount, expectedAgentSystemIdentitiesCount, userAssignedIdentitiesCount, expectedAgentUserAssignedIdentitiesCount)
 		}
 
 		if expectedAgentUserAssignedIdentitiesCount != userAssignedIdentitiesCount {
@@ -321,7 +321,7 @@ func TestDeployAzureDevOpsLinuxAndWindowsAgents(t *testing.T) {
 }
 
 // This function tests the deployment of Azure DevOps Linux agents into an existing resource group
-func TestDeployAzureDevOpsLinuxAgentsIntoExistingRresourceGroup(t *testing.T) {
+func TestDeployAzureDevOpsLinuxAgentsIntoExistingResourceGroup(t *testing.T) {
 	t.Parallel()
 
 	fixtureFolder := "./fixture/linux-agents-import-rg"
@@ -513,7 +513,7 @@ func getAgentPool(ctx context.Context, devopsTaskAgentClient taskagent.Client, d
 	return &(*matchingAgentPools)[0], nil
 }
 
-func removeQuotes(s string) (string) {
+func removeQuotes(s string) string {
 	if len(s) > 0 && s[0] == '"' {
 		s = s[1:]
 	}

--- a/test/fixture/linux-agents-import-rg/variables.tf
+++ b/test/fixture/linux-agents-import-rg/variables.tf
@@ -16,7 +16,7 @@ variable "azure_devops_personal_access_token" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westeurope"
+  default     = "northeurope"
 }
 
 variable "agent_docker_image" {

--- a/test/fixture/linux-agents-managed-identities/variables.tf
+++ b/test/fixture/linux-agents-managed-identities/variables.tf
@@ -16,7 +16,7 @@ variable "azure_devops_personal_access_token" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westeurope"
+  default     = "northeurope"
 }
 
 variable "agent_docker_image" {

--- a/test/fixture/linux-agents-private-registry/variables.tf
+++ b/test/fixture/linux-agents-private-registry/variables.tf
@@ -16,7 +16,7 @@ variable "azure_devops_personal_access_token" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westeurope"
+  default     = "northeurope"
 }
 
 variable "agent_docker_image" {

--- a/test/fixture/linux-agents-vnet/variables.tf
+++ b/test/fixture/linux-agents-vnet/variables.tf
@@ -16,7 +16,7 @@ variable "azure_devops_personal_access_token" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westus"
+  default     = "northeurope"
 }
 
 variable "agent_docker_image" {

--- a/test/fixture/linux-agents/variables.tf
+++ b/test/fixture/linux-agents/variables.tf
@@ -16,7 +16,7 @@ variable "azure_devops_personal_access_token" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westeurope"
+  default     = "northeurope"
 }
 
 variable "agent_docker_image" {

--- a/test/fixture/linux-and-windows-agents/variables.tf
+++ b/test/fixture/linux-and-windows-agents/variables.tf
@@ -23,7 +23,7 @@ variable "windows_azure_devops_pool_name" {
 variable "location" {
   type        = string
   description = "The Azure location to use"
-  default     = "westeurope"
+  default     = "northeurope"
 }
 
 variable "linux_agent_docker_image" {


### PR DESCRIPTION
- Tests were not running from the same region. Updating all to run from `northeurope`.
- Switch back to the MCR published Terraform test Docker image
- Fix type in test function name
- Fixes #24 - test subscription struggled with deployment in west us (probably some quotas issue)