### PR TITLE
feat: expose identity ID attr for registry credential

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,12 +63,21 @@ resource "azurerm_container_group" "linux-container-group" {
   }
 
   # if an image registry server has been specified, then generate the image_registry_credential block.
+  # For a credential with a username and a password
   dynamic "image_registry_credential" {
-    for_each = var.image_registry_credential.server == "" ? [] : [1]
+    for_each = var.image_registry_credential.server != "" && var.image_registry_credential.user_assigned_identity_id == "" ? [1] : []
     content {
       username = var.image_registry_credential.username
       password = var.image_registry_credential.password
       server   = var.image_registry_credential.server
+    }
+  }
+  # For a credential with an identity ID
+  dynamic "image_registry_credential" {
+    for_each = var.image_registry_credential.server != "" && var.image_registry_credential.user_assigned_identity_id != "" ? [1] : []
+    content {
+      server                    = var.image_registry_credential.server
+      user_assigned_identity_id = var.image_registry_credential.user_assigned_identity_id
     }
   }
 
@@ -141,12 +150,28 @@ resource "azurerm_container_group" "windows-container-group" {
   }
 
   # if an image registry server has been specified, then generate the image_registry_credential block.
+  # For a credential with a username and a password
   dynamic "image_registry_credential" {
-    for_each = var.image_registry_credential.server == "" ? [] : [1]
+    for_each = (
+      (
+        var.image_registry_credential.server != "" &&
+        var.image_registry_credential.username != "" &&
+        var.image_registry_credential.password != ""
+      )
+      ? [1] : []
+    )
     content {
       username = var.image_registry_credential.username
       password = var.image_registry_credential.password
       server   = var.image_registry_credential.server
+    }
+  }
+  # For a credential with an identity ID
+  dynamic "image_registry_credential" {
+    for_each = var.image_registry_credential.server != "" && var.image_registry_credential.user_assigned_identity_id != "" ? [1] : []
+    content {
+      server                    = var.image_registry_credential.server
+      user_assigned_identity_id = var.image_registry_credential.user_assigned_identity_id
     }
   }
 }

--- a/test/fixture/linux-agents-import-rg/provider.tf
+++ b/test/fixture/linux-agents-import-rg/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/test/fixture/linux-agents-managed-identities/provider.tf
+++ b/test/fixture/linux-agents-managed-identities/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/test/fixture/linux-agents-private-registry/provider.tf
+++ b/test/fixture/linux-agents-private-registry/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/test/fixture/linux-agents-vnet/provider.tf
+++ b/test/fixture/linux-agents-vnet/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/test/fixture/linux-agents/provider.tf
+++ b/test/fixture/linux-agents/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/test/fixture/linux-and-windows-agents/provider.tf
+++ b/test/fixture/linux-and-windows-agents/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.16.0"
+      version = ">= 3.29.0"
     }
   }
 }
@@ -10,3 +10,4 @@ terraform {
 provider "azurerm" {
   features {}
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -98,15 +98,23 @@ variable "windows_agents_configuration" {
 
 variable "image_registry_credential" {
   type = object({
-    username = string,
-    password = string,
-    server   = string
+    username                  = optional(string, ""),
+    password                  = optional(string, ""),
+    server                    = string,
+    user_assigned_identity_id = optional(string, ""),
   })
   description = "(Optional) The credentials to use to connect to the Docker private registry where agent images are stored."
   default = {
-    username = "",
-    password = "",
-    server   = ""
+    server = "",
+  }
+
+  validation {
+    condition = (
+      var.image_registry_credential.server == "" ||
+      (var.image_registry_credential.username != "" && var.image_registry_credential.password != "") ||
+      var.image_registry_credential.user_assigned_identity_id != ""
+    )
+    error_message = "Either a username and a password or a user assigned identity ID must be provided to connect to the Docker private registry."
   }
 }
 
@@ -117,5 +125,5 @@ variable "dns_config" {
     options        = optional(list(string))
   })
   description = "(Optional) The DNS config information for a container group."
-  default = null
+  default     = null
 }


### PR DESCRIPTION
This PR aims to allow the module users to specify [`user_assigned_identity_id`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group#user_assigned_identity_id) of the `image_registry_credential` attribute  for the `azurerm_container_group` resource to pull an image from a private Azure Container Registry with a managed identity instead of a username and a password.

I think the [`user_assigned_identity_id`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group#user_assigned_identity_id) attributes has been supported since azurerm v3.29.0.
https://github.com/hashicorp/terraform-provider-azurerm/blame/main/internal/services/containers/container_group_resource.go#L101
